### PR TITLE
Add Support for automated builds on Intel hosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+
+services:
+  - docker
+
+install: true
+
+before_script:
+  - sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static
+  - echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register
+
+script:
+  - docker build -t sedden/plex-server-docker-rpi:latest plex
+
+after_success: |
+  if [ -n "${DOCKER_EMAIL}" ] && [ -n "${DOCKER_TOKEN}" ] && [ "${TRAVIS_PULL_REQUEST}" = 'false' ]
+  then
+    mkdir -p $HOME/.docker
+    echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"${DOCKER_TOKEN}\",\"email\":\"${DOCKER_EMAIL}\"}}}" > $HOME/.docker/config.json
+    docker push sedden/plex-server-docker-rpi:latest || exit 1
+  fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Plex Server for Raspberry Pi
 
+[![Build Status](https://travis-ci.org/sedden/plex-server-docker-rpi.svg?branch=master)](https://travis-ci.org/sedden/plex-server-docker-rpi)
+
 A simple way to run a plex media server in Docker on the Raspberry Pi 2 or 3.
 
 NOTE: The Pi 1 is NOT supported.
@@ -52,7 +54,7 @@ If you experience problems with media that should direct play/stream to your cli
     mkdir /home/pi/plex/data/transcoder
 
 Then add `/data/transcoder` to `Settings -> Server -> Transcoder -> Transcoder temporary directory` in the Plex admin.
-    
+
 Why? Most of the time your SD card will be realtively small 16/32Gb and can quickly run out of space. According to [this forum post](https://forums.plex.tv/discussion/206281/there-was-a-problem-playing-this-item), the lack of available space can cause transcoder problems.
 
 ## Development

--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian:jessie
+FROM sedden/rpi-raspbian-qemu:jessie
 
 # Dependencies
 RUN apt-get update \


### PR DESCRIPTION
In order to enable automated builds on Intel hosts, the images must contain the `qemu-arm-static` binary. For that reason, the image now extends `sedden/rpi-raspbian-qemu`:
- https://github.com/sedden/docker-rpi-raspbian-qemu
- https://hub.docker.com/r/sedden/rpi-raspbian-qemu/

The automated build is currently powered by Travis CI. [binfmt-support](http://www.nongnu.org/binfmt-support/) is used to register ARM binaries to be executed by `/usr/bin/qemu-arm-static`. The `.travis.yml` contains this part:

```
before_script:
  - sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static
  - echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register
```

This pull-request could easily be improved by adding more configuration options for the Travis CI build (like Docker Hub username/image name, ...).

Please let me know if you're interested in adding support for automated builds on Intel hosts (or not). Thanks! :-) 
